### PR TITLE
Changed the path to open the project in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Make sure you have the [.NET Core SDK](https://www.microsoft.com/net/download/ma
 
 ```
 git clone https://github.com/nbarbettini/little-aspnetcore-todo.git
-cd little-aspnetcore-todo
+cd little-aspnetcore-todo/AspNetCoreTodo
 dotnet run
 ```
 


### PR DESCRIPTION
The Path was just entering the root point of this repo. In order to run ´dotnet run´ you need to be in the directory where project really is.


Closing #12 with this.